### PR TITLE
refactor: Apply looser precheck hook

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -14,20 +14,13 @@ import {
 } from './telepon';
 
 /**
- * Attempt to parse a telephone number from the provided string.
+ * Do pre sanitize and early validation on a phone number string
  *
- * @param {string} tel a string containing telephone number
- * @returns {Telepon} parsed input as telephone number with metadata
- * information
+ * @param {string} tel phone number string
+ * @returns {string} sanitized phone number string
  */
-export function parse(tel: string): Telepon {
+function precheck(tel: string): string {
   let input = tel.replace(/[^\d\s\-\+]/g, '');
-
-  const emergencyNumber = isEmergencyLine(input);
-
-  if (emergencyNumber) {
-    return emergencyNumber;
-  }
 
   if (input.startsWith('+') && input.slice(1, 3) !== '62') {
     throw new AmbiguousNumberException();
@@ -39,9 +32,34 @@ export function parse(tel: string): Telepon {
 
   input = input.replace(/[^\d]/g, '');
 
-  if (!input.startsWith('0') && !input.startsWith('+62')) {
+  if (input.startsWith('62')) {
+    input = `0${input.slice(2)}`;
+  }
+
+  if (!input.startsWith('0')) {
     throw new AmbiguousNumberException();
   }
+
+  return input;
+}
+
+/**
+ * Attempt to parse a telephone number from the provided string.
+ *
+ * @param {string} tel a string containing telephone number
+ * @returns {Telepon} parsed input as telephone number with metadata
+ * information
+ */
+export function parse(tel: string): Telepon {
+  const emergencyNumber = isEmergencyLine(
+    tel.replace(/[^\d]/, ''),
+  );
+
+  if (emergencyNumber) {
+    return emergencyNumber;
+  }
+
+  const input = precheck(tel);
 
   const number = isFixedLine(input) ?? isMobileNumber(input);
 
@@ -79,21 +97,7 @@ export function parseAsEmergency(tel: string): EmergencyService {
  * metadata information
  */
 export function parseAsFixedLine(tel: string): FixedTelepon {
-  let input = tel.replace(/[^\d\s\-\+]/g, '');
-
-  if (input.startsWith('+') && input.slice(1, 3) !== '62') {
-    throw new AmbiguousNumberException();
-  }
-
-  if (input.startsWith('+62')) {
-    input = `0${input.slice(3)}`;
-  }
-
-  input = input.replace(/[^\d]/g, '');
-
-  if (!input.startsWith('0') && !input.startsWith('+62')) {
-    throw new AmbiguousNumberException();
-  }
+  const input = precheck(tel);
 
   const fixedLine = isFixedLine(input);
 
@@ -113,21 +117,7 @@ export function parseAsFixedLine(tel: string): FixedTelepon {
  * metadata information
  */
 export function parseAsMobile(tel: string): MobileTelepon {
-  let input = tel.replace(/[^\d\s\-\+]/g, '');
-
-  if (input.startsWith('+') && input.slice(1, 3) !== '62') {
-    throw new AmbiguousNumberException();
-  }
-
-  if (input.startsWith('+62')) {
-    input = `0${input.slice(3)}`;
-  }
-
-  input = input.replace(/[^\d]/g, '');
-
-  if (!input.startsWith('0') && !input.startsWith('+62')) {
-    throw new AmbiguousNumberException();
-  }
+  const input = precheck(tel);
 
   const mobile = isMobileNumber(input);
 


### PR DESCRIPTION
## Overview

This pull request applies looser precheck step which allows number to be prefixed with only `62` (without the plus sign)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2--canary.1.e003236c1a3a511feb9663962f1e66196744897d.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/telepon@1.0.2--canary.1.e003236c1a3a511feb9663962f1e66196744897d.0
  # or 
  yarn add @namchee/telepon@1.0.2--canary.1.e003236c1a3a511feb9663962f1e66196744897d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
